### PR TITLE
fix: wrong ratio in  zoom

### DIFF
--- a/example/main.ts
+++ b/example/main.ts
@@ -70,7 +70,7 @@ const ratio = ((context: any) => {
     context.oBackingStorePixelRatio ||
     context.backingStorePixelRatio ||
     1
-  return (window.devicePixelRatio || 1) / backingStore
+  return Math.max(window.devicePixelRatio, 1) / backingStore
 })(ctx)
 
 let drawing = false


### PR DESCRIPTION
当缩放 devicePixelRatio 小于 1 时， 会出现如图情况。

<img width="2009" alt="image" src="https://github.com/user-attachments/assets/0a65da76-8495-4160-8c96-826d771690d2">